### PR TITLE
[WIP] FreeDink 108.4

### DIFF
--- a/freedink.rb
+++ b/freedink.rb
@@ -1,0 +1,39 @@
+require "formula"
+
+class Freedink < Formula
+  homepage "http://www.gnu.org/software/freedink/"
+  url "http://ftpmirror.gnu.org/freedink/freedink-108.4.tar.gz"
+  mirror "https://ftp.gnu.org/pub/gnu/freedink/freedink-108.4.tar.gz"
+  sha1 "b487b7d0bb56c83e9cf14b903b89a3f8fca99fdc"
+
+  head "git://git.savannah.gnu.org/freedink.git"
+
+  depends_on "pkg-config" => :build
+  depends_on "check"
+  depends_on "sdl"
+  depends_on "sdl_gfx"
+  depends_on "sdl_image"
+  depends_on "sdl_mixer"
+  depends_on "sdl_ttf"
+  depends_on "gettext"
+  depends_on "libffi"
+  depends_on "libzzip"
+  depends_on "fontconfig"
+
+  resource "freedink-data" do
+    url "http://ftpmirror.gnu.org/freedink/freedink-data-1.08.20140901.tar.gz"
+    mirror "https://ftp.gnu.org/gnu/freedink/freedink-data-1.08.20140901.tar.gz"
+    sha1 "a27a7c73b7bc056890262c0ff7a48a7d16e1651b"
+  end
+
+  def install
+    args = ["--prefix=#{prefix}",
+            "--datarootdir=#{share}",
+            "--disable-dependency-tracking"]
+
+    system "./configure", *args
+    system "make", "install"
+
+    (share/"dink").install resource("freedink-data")
+  end
+end


### PR DESCRIPTION
Here's a formula for the FreeDink game, based on this Portfile: http://trac.macports.org/browser/trunk/dports/games/freedink/Portfile

This isn't ready to merge yet since, when running the game, I get these image loading errors which I think are coming from `sdl_image`:

> [ERROR] Sprite_load_pak error:  Couldn't load dinkL-01.bmp in /usr/local/Cellar/freedink/108.4/share/dink/dink/graphics/Startme/options/dir.ff.
>[ERROR] Failed to load but3-01.bmp from fastfile /usr/local/Cellar/freedink/108.4/share/dink/dink/graphics/Startme/options/dir.ff: Unsupported image format
> [ERROR] Failed to load but3-01.bmp from fastfile /usr/local/Cellar/freedink/108.4/share/dink/dink/graphics/Startme/options/dir.ff (see error above)
> [ERROR] Sprite_load_pak error:  Couldn't load but3-01.bmp in /usr/local/Cellar/freedink/108.4/share/dink/dink/graphics/Startme/options/dir.ff.

And one of the tests is failing with this error in the `brew bottle` test:
> the __LINKEDIT segment does not cover the end of the file (can't be processed) in: /usr/local/Cellar/freedink/108.4/bin/freedink
> Error: Failure while executing: /usr/bin/install_name_tool -change /usr/local/opt/gettext/lib/libintl.8.dylib @@HOMEBREW_PREFIX@@/opt/gettext/lib/libintl.8.dylib /usr/local/Cellar/freedink/108.4/bin/freedink