### PR TITLE
fuego: update revision 1981

### DIFF
--- a/fuego.rb
+++ b/fuego.rb
@@ -1,14 +1,16 @@
-require 'formula'
-
 class Fuego < Formula
-  url 'https://downloads.sourceforge.net/project/fuego/fuego/1.0/fuego-1.0.tar.gz'
   homepage 'http://fuego.sourceforge.net/'
-  sha1 '1fe3de726d7020278f7cb2f678a1909053bf0107'
+  head "http://svn.code.sf.net/p/fuego/code/trunk"
+  url "http://svn.code.sf.net/p/fuego/code/trunk", :revision => 1981
+  version "1.1.SVN"
 
+  # automake should be a build dep, but won't install otherwise
+  depends_on 'automake'
   depends_on 'boost'
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
-    system "make install"
+    system "autoreconf", "--force", "--install"
+    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
+    system "make", "install"
   end
 end


### PR DESCRIPTION
older versions of fuego don't work with recent boost versions
revision 1981 is the current as of this pull request, but realistically this formula should be head only until a stable version is determined