### PR TITLE
xboard: brew audit --strict

### DIFF
--- a/xboard.rb
+++ b/xboard.rb
@@ -1,14 +1,14 @@
 class Xboard < Formula
-  homepage 'https://www.gnu.org/software/xboard/'
-  url 'http://ftpmirror.gnu.org/xboard/xboard-4.7.3.tar.gz'
-  mirror 'https://ftp.gnu.org/gnu/xboard/xboard-4.7.3.tar.gz'
-  sha1 'dab9a69f3c8afd70a7a2e5e31f48d31fd9fbbabb'
+  homepage "https://www.gnu.org/software/xboard/"
+  url "http://ftpmirror.gnu.org/xboard/xboard-4.7.3.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/xboard/xboard-4.7.3.tar.gz"
+  sha256 "7fd0b03f53dad57c587bc3438459612e2455534f715cfb0e637b6290f34cbeaa"
 
-  depends_on 'pkg-config' => :build
-  depends_on 'fairymax' => :recommended
-  depends_on 'gettext'
-  depends_on 'cairo'
-  depends_on 'librsvg'
+  depends_on "pkg-config" => :build
+  depends_on "fairymax" => :recommended
+  depends_on "gettext"
+  depends_on "cairo"
+  depends_on "librsvg"
   depends_on :x11
 
   def install
@@ -19,6 +19,10 @@ class Xboard < Formula
 
     system "./configure", *args
     system "make"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"xboard", "--help"
   end
 end


### PR DESCRIPTION
There is a version 4.8.0 out now. I was trying to update the formula to that version, but I've had bum luck getting a working build out of it.

But since I gussied it up to pass `brew audit --strict` (including adding a rudimentary validation test), I thought I should share at least that much.