### PR TITLE
openclonk: Bump version to 6.1

### DIFF
--- a/openclonk.rb
+++ b/openclonk.rb
@@ -1,18 +1,9 @@
 class Openclonk < Formula
-  homepage "http://www.openclonk.org"
-  url "https://github.com/openclonk/openclonk/archive/v6.0.tar.gz"
-  sha256 "1daa437a598f09375d85d0cd6cfb8655f285ae9f1939221cea2f587e531133ba"
   head "https://github.com/openclonk/openclonk", :using => :git
+  url "https://github.com/openclonk/openclonk/archive/v6.1.tar.gz"
+  homepage "http://www.openclonk.org"
+  sha256 "4e2e6cefedd4a13523593b285af23b530caa3a98ff02ac4adb215cf32889cb94"
 
-  bottle do
-    root_url "https://homebrew.bintray.com/bottles-games"
-    cellar :any
-    sha256 "3e61a12dca0998d1c0a78466569abb325c32a26549034b1569cb187f479082d0" => :yosemite
-    sha256 "76e83695bfa80b4387004961a6693d555993a4a603cdcd386908edfbd195592a" => :mavericks
-    sha256 "f31c5f4100c5bd8ab22ca8d25dbf52df5b40ffbaed1567f1cb325547fcafcf2a" => :mountain_lion
-  end
-
-  depends_on :macos => :mountain_lion
   depends_on "cmake" => :build
   depends_on "jpeg"
   depends_on "libpng"
@@ -24,16 +15,6 @@ class Openclonk < Formula
   depends_on "freealut"
 
   needs :cxx11
-
-  patch do
-    url "https://github.com/openclonk/openclonk/commit/5c9d687d67a5c159a07dabb385b236996f6de668.diff"
-    sha256 "93c2698bf20cf8cf6c11cf6a128dd4841435efa47ca4ced06c2ace0e60f63481"
-  end
-
-  patch do
-    url "https://github.com/openclonk/openclonk/commit/c82adb78537515c02368678e39942c4df61d7bd5.diff"
-    sha256 "5736fb918002cb3a5cc096d00656664aa5ba944c7ca60a963bc8c6597328384b"
-  end
 
   def install
     ENV.cxx11

--- a/openclonk.rb
+++ b/openclonk.rb
@@ -1,9 +1,18 @@
 class Openclonk < Formula
   head "https://github.com/openclonk/openclonk", :using => :git
-  url "https://github.com/openclonk/openclonk/archive/v6.1.tar.gz"
   homepage "http://www.openclonk.org"
+  url "https://github.com/openclonk/openclonk/archive/v6.1.tar.gz"
   sha256 "4e2e6cefedd4a13523593b285af23b530caa3a98ff02ac4adb215cf32889cb94"
 
+  bottle do
+    root_url "https://homebrew.bintray.com/bottles-games"
+    cellar :any
+    sha256 "3e61a12dca0998d1c0a78466569abb325c32a26549034b1569cb187f479082d0" => :yosemite
+    sha256 "76e83695bfa80b4387004961a6693d555993a4a603cdcd386908edfbd195592a" => :mavericks
+    sha256 "f31c5f4100c5bd8ab22ca8d25dbf52df5b40ffbaed1567f1cb325547fcafcf2a" => :mountain_lion
+  end
+
+  depends_on :macos => :mountain_lion
   depends_on "cmake" => :build
   depends_on "jpeg"
   depends_on "libpng"


### PR DESCRIPTION
That bumps the version for the openclonk formula to 6.1

It also removes the patches since they are integrated in the main line.