### PR TITLE
Gtk+ goes quartz only

### DIFF
--- a/fceux.rb
+++ b/fceux.rb
@@ -17,7 +17,8 @@ class Fceux < Formula
   # Reported upstream: https://sourceforge.net/p/fceultra/bugs/625
   # Also temporarily kill Lua support pending further investigation as to build failures.
   # It is listed as "Optional" in the build docs, but will be reinstated asap.
-  # Additional patches added to remove all traces of X11 and to enable a build against gtk+3
+  # Additional patches added to remove all traces of X11 and to enable a build against gtk+3.
+  # Filed as bug https://sourceforge.net/p/fceultra/bugs/703/
   patch :DATA
 
   def install

--- a/fceux.rb
+++ b/fceux.rb
@@ -1,31 +1,35 @@
-require 'formula'
-
 class Fceux < Formula
-  homepage 'http://fceux.com'
-  url 'https://downloads.sourceforge.net/project/fceultra/Source%20Code/2.2.2%20src/fceux-2.2.2.src.tar.gz'
-  sha1 'ec50d8eae04794ba10f441a26cdb410c1cf6832b'
-  revision 1
+  desc "The all in one NES/Famicom Emulator"
+  homepage "http://fceux.com"
+  url "https://downloads.sourceforge.net/project/fceultra/Source%20Code/2.2.2%20src/fceux-2.2.2.src.tar.gz"
+  sha256 "804d11bdb4a195f3a580ce5d2d01be877582763378637e16186a22459f5fe5e1"
+  revision 2
 
-  option 'no-gtk', "Build without Gtk+ support"
+  deprecated_option "no-gtk" => "without-gtk+3"
 
-  depends_on 'pkg-config' => :build
-  depends_on 'scons' => :build
-  depends_on 'sdl'
-  depends_on 'libzip'
-  depends_on 'gtk+' unless build.include? "no-gtk"
-  depends_on :x11
+  depends_on "pkg-config" => :build
+  depends_on "scons" => :build
+  depends_on "sdl"
+  depends_on "libzip"
+  depends_on "gtk+3" => :recommended
 
   # Make scons honor PKG_CONFIG_PATH and PKG_CONFIG_LIBDIR
   # Reported upstream: https://sourceforge.net/p/fceultra/bugs/625
   # Also temporarily kill Lua support pending further investigation as to build failures.
-  # It is listed as 'Optional' in the build docs, but will be reinstated asap.
+  # It is listed as "Optional" in the build docs, but will be reinstated asap.
+  # Additional patches added to remove all traces of X11 and to enable a build against gtk+3
   patch :DATA
 
   def install
     args = []
-    args << "GTK=0" if build.include? "no-gtk"
+    args << "GTK=0"
+    args << ((build.with? "gtk+3") ? "GTK3=1" : "GTK3=0")
     scons *args
-    bin.install 'src/fceux'
+    bin.install "src/fceux"
+  end
+
+  test do
+    system "fceux", "-h"
   end
 end
 
@@ -76,14 +80,53 @@ index dc6698e..a23350a 100644
    BoolVariable('GTK3', 'Enable GTK3 GUI (SDL only)', 0),
    BoolVariable('NEWPPU',    'Enable new PPU core', 1),
 diff --git a/src/drivers/sdl/SConscript b/src/drivers/sdl/SConscript
-index 7a53b07..23e11b9 100644
+index 7a53b07..6a9cbeb 100644
 --- a/src/drivers/sdl/SConscript
 +++ b/src/drivers/sdl/SConscript
-@@ -2,8 +2,6 @@
- # Thanks Antonio Ospite!
- Import('env')
- config_string = 'pkg-config --cflags --libs x11'
+@@ -1,12 +1,3 @@
+-# Fix compliation error about 'XKeysymToString' by linking X11 explicitly
+-# Thanks Antonio Ospite!
+-Import('env')
+-config_string = 'pkg-config --cflags --libs x11'
 -if env['PLATFORM'] == 'darwin':
 -  config_string = 'PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig/ ' + config_string
- env.ParseConfig(config_string)
- Export('env')
+-env.ParseConfig(config_string)
+-Export('env')
+-
+ source_list = Split(
+     """
+     input.cpp
+diff --git a/src/drivers/sdl/gui.cpp b/src/drivers/sdl/gui.cpp
+index 98d4471..5599b35 100644
+--- a/src/drivers/sdl/gui.cpp
++++ b/src/drivers/sdl/gui.cpp
+@@ -20,7 +20,6 @@
+ 
+ #include <gtk/gtk.h>
+ #include <gdk/gdkkeysyms.h>
+-#include <gdk/gdkx.h>
+ 
+ #ifdef _GTK3
+ #include <gdk/gdkkeysyms-compat.h>
+@@ -1158,7 +1157,7 @@ void openSoundConfig()
+ 										NULL);
+ 	gtk_window_set_icon_name(GTK_WINDOW(win), "audio-x-generic");
+ 	main_hbox = gtk_hbox_new(FALSE, 15);
+-	vbox = gtk_vbox_new(False, 5);
++	vbox = gtk_vbox_new(FALSE, 5);
+ 
+ 	// sound enable check
+ 	soundChk = gtk_check_button_new_with_label("Enable sound");
+diff --git a/src/drivers/sdl/sdl-video.cpp b/src/drivers/sdl/sdl-video.cpp
+index 88aacd3..ed9ef3e 100644
+--- a/src/drivers/sdl/sdl-video.cpp
++++ b/src/drivers/sdl/sdl-video.cpp
+@@ -42,7 +42,6 @@
+ 
+ #ifdef _GTK
+ #include "gui.h"
+-#include <gdk/gdkx.h>
+ #endif
+ 
+ #include <cstdio>
+

--- a/freeciv.rb
+++ b/freeciv.rb
@@ -1,16 +1,10 @@
 class Freeciv < Formula
+  desc "A Free and Open Source empire-building strategy game"
   homepage "http://freeciv.wikia.com"
   url "https://downloads.sourceforge.net/project/freeciv/Freeciv%202.5/2.5.0/freeciv-2.5.0.tar.bz2"
   mirror "http://download.gna.org/freeciv/stable/freeciv-2.5.0.tar.bz2"
   sha256 "bd9f7523ea79b8d2806d0c1844a9f48506ccd18276330580319913c43051210b"
-
-  head do
-    url "svn://svn.gna.org/svn/freeciv/trunk"
-    depends_on "automake" => :build
-    depends_on "autoconf" => :build
-    depends_on "gettext" => :build
-    depends_on "libtool" => :build
-  end
+  revision 1
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles-games"
@@ -20,16 +14,21 @@ class Freeciv < Formula
     sha256 "f3a1c6f0606dce6b0a2d9bc7c854867c5be127c6a60eea497189d208d816a35e" => :mountain_lion
   end
 
+  head do
+    url "svn://svn.gna.org/svn/freeciv/trunk"
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "gettext" => :build
+    depends_on "libtool" => :build
+  end
+
   option "without-nls", "Disable NLS support"
   option "without-sdl", "Disable the SDL Freeciv client"
-  option "without-gtk+", "Disable the GTK+ Freeciv client"
-  option "with-gtk+3", "Enable the GTK+3 Freeciv client"
 
   depends_on "gettext" if build.with? "nls"
   depends_on "icu4c"
   depends_on "pkg-config" => :build
   depends_on "readline"
-  depends_on :x11
 
   depends_on "sdl" => :recommended
   if build.with? "sdl"
@@ -40,14 +39,7 @@ class Freeciv < Formula
     depends_on "sdl_ttf"
   end
 
-  depends_on "gtk+" => :recommended
-  depends_on "gtk+3" => :optional
-  if build.with?("gtk+") || build.with?("gtk+3")
-    depends_on "atk"
-    depends_on "glib"
-    depends_on "pango"
-  end
-  depends_on "gdk-pixbuf" if build.with? "gtk+3"
+  depends_on "gtk+3" => :recommended
 
   def install
     args = %W[

--- a/pioneers.rb
+++ b/pioneers.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class Pioneers < Formula
+  desc "A Settlers of Catan clone"
   homepage "http://pio.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/pio/Source/pioneers-15.1.tar.gz"
-  sha1 "cea94cd77edef31b3f9e601077dff9b199dfeaf4"
+  url "https://downloads.sourceforge.net/project/pio/Source/pioneers-15.3.tar.gz"
+  sha256 "69afa51b71646565536b571b0f89786d3a7616965265f196fd51656b51381a89"
 
   fails_with :clang do
     build 318
@@ -13,10 +12,8 @@ class Pioneers < Formula
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
   depends_on "gettext"
-  depends_on "gtk+"
-  depends_on "gdk-pixbuf"
+  depends_on "gtk+3"
   depends_on "librsvg" # svg images for gdk-pixbuf
-  depends_on "hicolor-icon-theme"
 
   def install
     # fix usage of echo options not supported by sh
@@ -30,6 +27,15 @@ class Pioneers < Formula
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/pioneers-editor", "--help"
+    server = fork do
+      system "#{bin}/pioneers-server-console"
+    end
+    sleep 5
+    Process.kill("TERM", server)
   end
 end


### PR DESCRIPTION
This branch continues my work in Homebrew/homebrew#39868, Homebrew/homebrew-science#2311 and Homebrew/homebrew-x11#83 regarding removing X11 support in Gtk+ and its dependencies cairo and pango in favor of quartz.

I found the following packages in this tap to have a mandatory or recommended dependency on gtk+:

- [x] fceux
- [x] freeciv
- [x] pioneers 

Since these three packages are now all depending on `gtk+3` instead of `gtk+`, they can be merged in independently of the aforementioned PRs.