### PR TITLE
fceux: patch SConstruct to point to correct LUA5.1 include folder

### DIFF
--- a/fceux.rb
+++ b/fceux.rb
@@ -19,6 +19,7 @@ class Fceux < Formula
   depends_on "sdl"
   depends_on "libzip"
   depends_on "gtk+3" => :recommended
+  depends_on "lua51" => :build
 
   # Make scons honor PKG_CONFIG_PATH and PKG_CONFIG_LIBDIR
   # Reported upstream: https://sourceforge.net/p/fceultra/bugs/625
@@ -74,19 +75,15 @@ index 4d5b446..36be2c4 100644
      env.ParseConfig(config_string)
      env.Append(CPPDEFINES=["_GTK3"])
      env.Append(CCFLAGS = ["-D_GTK"])
-diff --git a/SConstruct b/SConstruct
-index dc6698e..a23350a 100644
---- a/SConstruct
-+++ b/SConstruct
-@@ -18,7 +18,7 @@ opts.AddVariables(
-   BoolVariable('RELEASE',   'Set to 1 to build for release', 1),
-   BoolVariable('FRAMESKIP', 'Enable frameskipping', 1),
-   BoolVariable('OPENGL',    'Enable OpenGL support', 1),
--  BoolVariable('LUA',       'Enable Lua support', 1),
-+  BoolVariable('LUA',       'Enable Lua support', 0),
-   BoolVariable('GTK', 'Enable GTK2 GUI (SDL only)', 1),
-   BoolVariable('GTK3', 'Enable GTK3 GUI (SDL only)', 0),
-   BoolVariable('NEWPPU',    'Enable new PPU core', 1),
+@@ -140,7 +140,7 @@ else:
+     lua_available = False
+     if conf.CheckLib('lua5.1'):
+       env.Append(LINKFLAGS = ["-ldl", "-llua5.1"])
+-      env.Append(CCFLAGS = ["-I/usr/include/lua5.1"])
++      env.Append(CCFLAGS = ["-I/usr/local/include/lua5.1"])
+       lua_available = True
+     elif conf.CheckLib('lua'):
+       env.Append(LINKFLAGS = ["-ldl", "-llua"])
 diff --git a/src/drivers/sdl/SConscript b/src/drivers/sdl/SConscript
 index 7a53b07..6a9cbeb 100644
 --- a/src/drivers/sdl/SConscript

--- a/fceux.rb
+++ b/fceux.rb
@@ -23,8 +23,6 @@ class Fceux < Formula
 
   # Make scons honor PKG_CONFIG_PATH and PKG_CONFIG_LIBDIR
   # Reported upstream: https://sourceforge.net/p/fceultra/bugs/625
-  # Also temporarily kill Lua support pending further investigation as to build failures.
-  # It is listed as "Optional" in the build docs, but will be reinstated asap.
   # Additional patches added to remove all traces of X11 and to enable a build against gtk+3.
   # Filed as bug https://sourceforge.net/p/fceultra/bugs/703/
   patch :DATA
@@ -80,7 +78,7 @@ index 4d5b446..36be2c4 100644
      if conf.CheckLib('lua5.1'):
        env.Append(LINKFLAGS = ["-ldl", "-llua5.1"])
 -      env.Append(CCFLAGS = ["-I/usr/include/lua5.1"])
-+      env.Append(CCFLAGS = ["-I/usr/local/include/lua5.1"])
++      env.Append(CCFLAGS = ["-IHOMEBREW_PREFIX/include/lua5.1"])
        lua_available = True
      elif conf.CheckLib('lua'):
        env.Append(LINKFLAGS = ["-ldl", "-llua"])


### PR DESCRIPTION
builds successfully and fceux menu now displays Load LUA script (i haven't actually tried running anything yet).