### PR TITLE
cataclysm: remove flags overriding

### DIFF
--- a/cataclysm.rb
+++ b/cataclysm.rb
@@ -35,12 +35,8 @@ class Cataclysm < Formula
     # top-level headers
     ENV.append_to_cflags "-I#{Formula["ncurses"].include}/ncursesw" if MacOS.version < :snow_leopard
 
-    # Because our CXXFLAGS override the default, need to set these for the tests to build
-    # See https://github.com/Homebrew/homebrew-games/issues/449
-    flags = [ENV.cxxflags, ENV.cppflags, "-I../src -Wno-unused-variable"].join(" ")
     args = %W[
       NATIVE=osx RELEASE=1 OSX_MIN=#{MacOS.version}
-      CXX=#{ENV.cxx} LD=#{ENV.cxx} CXXFLAGS=#{flags}
     ]
 
     args << "TILES=1" if build.with? "tiles"


### PR DESCRIPTION
In regards with #496, the culprit seemed to be our `CXXFLAGS` that wiped out internal parameters populated by `sdl2-config`. When I removed `CXXFLAGS`, it just built fine for both `stable` and `HEAD` with/without `tiles` option on OS X 10.11.

Removing `CXX` and `LD` didn't show any side effect either. If this could be a regression for older platforms, please let me know.

We could also get rid of `OSX_MIN` in the next release; it's upstream thanks to #484.