### PR TITLE
blastem 0.4.0

### DIFF
--- a/blastem.rb
+++ b/blastem.rb
@@ -1,9 +1,10 @@
 class Blastem < Formula
   desc "Fast and accurate Genesis emulator"
   homepage "http://rhope.retrodev.com/files/blastem.html"
-  url "http://rhope.retrodev.com/repos/blastem", :using => :hg, :revision => "c9ed929ee984"
-  version "0.3.1"
-  head "http://rhope.retrodev.com/repos/blastem"
+  url "http://rhope.retrodev.com/repos/blastem/archive/4a92889e2889.tar.gz"
+  version "0.4.0"
+  sha256 "fd820a1ef4cb8396ad4d32c4a703a500e3840ba25219f617c365a83685472c6d"
+  head "http://rhope.retrodev.com/repos/blastem", :using => :hg
 
   bottle do
     cellar :any
@@ -13,16 +14,54 @@ class Blastem < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "homebrew/python/pillow" => :build
+  depends_on "libpng" => :build # for xcftools
   depends_on "glew"
   depends_on "sdl2"
 
+  resource "vasm" do
+    url "http://server.owl.de/~frank/tags/vasm1_7e.tar.gz"
+    sha256 "2878c9c62bd7b33379111a66649f6de7f9267568946c097ffb7c08f0acd0df92"
+  end
+
+  resource "xcftools" do
+    url "http://henning.makholm.net/xcftools/xcftools-1.0.7.tar.gz"
+    sha256 "1ebf6d8405348600bc551712d9e4f7c33cc83e416804709f68d0700afde920a6"
+  end
+
   def install
+    resource("vasm").stage do
+      system "make", "CPU=m68k", "SYNTAX=mot"
+      (buildpath/"tool").install "vasmm68k_mot"
+    end
+
+    # FIXME: xcftools is not in the core tap
+    # https://github.com/Homebrew/homebrew-core/pull/1216
+    resource("xcftools").stage do
+      # Apply patch to build with libpng-1.5 or above
+      # http://anonscm.debian.org/cgit/collab-maint/xcftools.git/commit/?id=c40088b82c6a788792aae4068ddc8458de313a9b
+      inreplace "xcf2png.c", /png_(voidp|error_ptr)_NULL/, "NULL"
+
+      system "./configure"
+
+      # Avoid `touch` error from empty MANLINGUAS when building without NLS
+      touch "manpo/manpages.pot"
+      system "make", "manpo/manpages.pot"
+
+      system "make"
+      (buildpath/"tool").install "xcf2png"
+    end
+
+    ENV.prepend_path "PATH", buildpath/"tool"
+
+    # FIXME: missing dependency for font.tiles in Makefile
+    # http://rhope.retrodev.com/repos/blastem/rev/01a91df5b87c
+    system "make", "font.png"
+
+    system "make", "menu.bin"
     system "make"
-    libexec.install %w[blastem default.cfg rom.db shaders]
-    (bin/"blastem").write <<-EOS.undent
-      #!/bin/sh
-      exec "#{libexec}/blastem" "$@"
-      EOS
+    libexec.install %w[blastem default.cfg menu.bin rom.db shaders]
+    bin.write_exec_script libexec/"blastem"
   end
 
   test do


### PR DESCRIPTION
The new version provides GUI with its own rom `menu.bin`. To build this rom, [vasm](http://sun.hasenbraten.de/vasm/) and [xcftools](http://henning.makholm.net/software) are added for build-time resources.

There's an open PR for `xcftools` in the core tap: Homebrew/homebrew-core#1216.

I'm unsure if we could submit a PR for `vasm` too as it looks very customizable and each tool may require different configurations at its build-time.