### PR TITLE
go-gui: remove weird version specifier in Java dependency

### DIFF
--- a/go-gui.rb
+++ b/go-gui.rb
@@ -12,7 +12,7 @@ class GoGui < Formula
   end
 
   depends_on :ant => :build
-  depends_on :java => "1.6"
+  depends_on :java
 
   resource "quaqua" do
     url "http://www.randelshofer.ch/quaqua/files/quaqua-5.4.1.nested.zip"

--- a/go-gui.rb
+++ b/go-gui.rb
@@ -12,7 +12,7 @@ class GoGui < Formula
   end
 
   depends_on :ant => :build
-  depends_on :java
+  depends_on :java => "1.6+"
 
   resource "quaqua" do
     url "http://www.randelshofer.ch/quaqua/files/quaqua-5.4.1.nested.zip"


### PR DESCRIPTION
I'm actually not sure what this thing was even *trying* to accomplish; normally this is used for setting a scope, not a version. It was failing for me on a machine with the latest `brew cask install java` before, and now it's fine.

In any case, it's certainly *NOT* true that `go-gui` requires Java 1.6 specifically to run. Any later versions (like the latest 1.8) work just fine, and you'd be hard-pressed to find a Mac with Java <= 1.5 anyway.