### PR TITLE
Replaces location of Rogue tarball file

### DIFF
--- a/rogue.rb
+++ b/rogue.rb
@@ -1,7 +1,7 @@
 class Rogue < Formula
   desc "Dungeon crawling video game"
-  homepage "http://rogue.rogueforge.net/"
-  url "http://rogue.rogueforge.net/files/rogue5.4/rogue5.4.4-src.tar.gz"
+  homepage "http://rogue.rogueforge.net/" # no longer exists
+  url "http://pkgs.fedoraproject.org/repo/pkgs/rogue/rogue5.4.4-src.tar.gz/033288f46444b06814c81ea69d96e075/rogue5.4.4-src.tar.gz"
   version "5.4.4"
   sha256 "7d37a61fc098bda0e6fac30799da347294067e8e079e4b40d6c781468e08e8a1"
 


### PR DESCRIPTION
Seems that the original website (http://rogue.rogueforge.net/) is no longer available,
I'm replacing it so people can continue installing and playing Rogue.