### PR TITLE
dwarf-fortress: Remove x11 dependency

### DIFF
--- a/dwarf-fortress.rb
+++ b/dwarf-fortress.rb
@@ -13,7 +13,6 @@ class DwarfFortress < Formula
   end
 
   depends_on :arch => :intel
-  depends_on :x11
 
   def install
     # Dwarf Fortress uses freetype from X11, but hardcodes a path that


### PR DESCRIPTION
DF actually only requires freetype, which is bundled as of 0.43.05, at least in the 64-bit build.