### PR TITLE
go-gui: Switch to Unix-style installation

### DIFF
--- a/go-gui.rb
+++ b/go-gui.rb
@@ -3,6 +3,7 @@ class GoGui < Formula
   homepage "http://gogui.sourceforge.net"
   url "https://downloads.sourceforge.net/project/gogui/gogui/1.4.9/gogui-1.4.9.zip"
   sha256 "32684b756ab5b6bf9412c035594eddfd1be9250de12d348c3501850857b86662"
+  revision 1
 
   head do
     url "git://git.code.sf.net/p/gogui/code"
@@ -12,12 +13,17 @@ class GoGui < Formula
   end
 
   depends_on :ant => :build
-  depends_on :java => "1.6"
+  depends_on :java => "1.6+"
 
   resource "quaqua" do
     url "http://www.randelshofer.ch/quaqua/files/quaqua-5.4.1.nested.zip"
     sha256 "a01ce8bcce6e81941ca928468e728e76e0773957c685c349474ee04f3be677d6"
   end
+
+  # Disable Linux-specific install steps
+  # See https://github.com/Homebrew/homebrew-games/pull/598
+  # and https://sourceforge.net/p/gogui/bugs/43/
+  patch :DATA
 
   def install
     inreplace "build.xml", "/Developer/Tools/SetFile", "/usr/bin/SetFile"
@@ -35,13 +41,33 @@ class GoGui < Formula
         -Ddoc-uptodate=true
       ]
     end
-    system "ant", "gogui.app", *args
-    prefix.install "build/GoGui.app"
-    bin.write_exec_script "#{prefix}/GoGui.app/Contents/MacOS/JavaApplicationStub"
-    mv "#{bin}/JavaApplicationStub", "#{bin}/gogui"
+    # Use the Linux-style install instead of gogui.app to avoid Apple Java 1.6
+    # dependency. https://sourceforge.net/p/gogui/bugs/42/
+    system "./install.sh", "-p", prefix, "-j", "/usr"
   end
 
   test do
     assert_equal "GoGui #{version}", shell_output("#{bin}/gogui -version").chomp
   end
 end
+
+__END__
+diff --git a/install.sh b/install.sh
+index 848b399..3851420 100755
+--- a/install.sh
++++ b/install.sh
+@@ -94,6 +94,8 @@ install -m 644 config/gogui.desktop "$PREFIX/share/applications"
+ install -d "$PREFIX/share/mime/packages"
+ install -m 644 config/gogui-mime.xml "$PREFIX/share/mime/packages"
+ 
++if [ `uname` == 'linux' ]; then
++
+ # Install Gnome 2 thumbnailer
+ 
+ install -d "$SYSCONFDIR/gconf/schemas"
+@@ -126,3 +128,5 @@ update-desktop-database "$PREFIX/share/applications" >/dev/null 2>&1
+ # MIME database
+ 
+ update-mime-database "$PREFIX/share/mime" >/dev/null 2>&1
++
++fi


### PR DESCRIPTION
This removes the dependency on Apple's Java 1.6 that gogui.app has.

Closes #598.

This change loses the ability to do `brew linkapps go-gui`, because it no longer creates an application bundle. I don't know if that's something `go-gui` users are relying on.

Needs a bit of testing first, since it substantially changes the installation layout.

#### Upstream bugs

https://sourceforge.net/p/gogui/bugs/42/ – Apple Java 1.6 dependency
https://sourceforge.net/p/gogui/bugs/43/ – suggest conditionalizing installation of the Gnome stuff, to eliminate error message and extraneous files