### PR TITLE
advancemenu: use full path in the test

### DIFF
--- a/advancemenu.rb
+++ b/advancemenu.rb
@@ -18,6 +18,6 @@ class Advancemenu < Formula
   end
 
   test do
-    system "advmenu", "--version"
+    system bin/"advmenu", "--version"
   end
 end


### PR DESCRIPTION
fixes audit failure