### PR TITLE
--HEAD support for arx-libertatis

### DIFF
--- a/arx-libertatis.rb
+++ b/arx-libertatis.rb
@@ -12,7 +12,7 @@ class ArxLibertatis < Formula
   end
 
   head do
-    url "https://github.com/poldy/ArxLibertatis.git"
+    url "https://github.com/arx/ArxLibertatis.git"
 
     depends_on "cmake" => :build
     depends_on "inkscape" => :build

--- a/arx-libertatis.rb
+++ b/arx-libertatis.rb
@@ -11,6 +11,14 @@ class ArxLibertatis < Formula
     sha256 "8f1938381423b45d798c8a2665484b4f9a09b8070443b80986e935d07b0410af" => :mavericks
   end
 
+  head do
+    url "https://github.com/poldy/ArxLibertatis.git"
+
+    depends_on "cmake" => :build
+    depends_on "inkscape" => :build
+    depends_on "imagemagick" => :build
+  end
+
   option "without-innoextract", "Build without arx-install-data"
 
   depends_on "cmake" => :build


### PR DESCRIPTION
I have an open pull req with upstream to fix the build on Mac OS X. Assuming this is accepted, will need to install --HEAD until the next release is cut.